### PR TITLE
Nw fix student form

### DIFF
--- a/src/javascripts/components/student/editStudentForm.js
+++ b/src/javascripts/components/student/editStudentForm.js
@@ -1,35 +1,29 @@
 import utils from '../../helpers/utils';
 
 const showEditStudentForm = (fbStudentId, {
-  address,
-  name,
-  phoneNumber,
-  product,
-  studentId,
+  imageUrl,
+  studentName,
+  major,
 }) => {
   const domString = `
   <div class="container">
   <h2>Update Student</h2>
   <form class="hide" id="edit-student-form">
     <div class="form-group">
-      <label for="inputAddress">Address</label>
-      <input type="text" class="form-control" id="inputAddress" value="${address}">
+      <label for="inputImageUrl">Address</label>
+      <input type="text" class="form-control" id="inputImageUrl" value="${imageUrl}">
     </div>
     <div class="form-row">
       <div class="form-group col-md-6">
         <label for="inputName">Name</label>
-        <input type="text" class="form-control" id="inputName" value="${name}">
+        <input type="text" class="form-control" id="inputName" value="${studentName}">
       </div>
       <div class="form-group col-md-4">
-        <label for="inputPhone">Phone Number</label>
-        <input type="text" class="form-control" id="inputPhone" value="${phoneNumber}">
-      </div>
-      <div class="form-group col-md-2">
-        <label for="inputProduct">Product</label>
-        <input type="text" class="form-control" id="inputProduct" value="${product}">
+        <label for="inputMajor">Phone Number</label>
+        <input type="text" class="form-control" id="inputMajor" value="${major}">
       </div>
     </div>
-    <button type="submit" class="btn btn-primary" id="submit-update-student" data-firebase-student-id="${fbStudentId}" data-studentId="${studentId}">Update Student</button>
+    <button type="submit" class="btn btn-primary" id="submit-update-student" data-firebase-student-id="${fbStudentId}">Update Student</button>
   </form> 
   </div>
   `;

--- a/src/javascripts/components/student/newStudentForm.js
+++ b/src/javascripts/components/student/newStudentForm.js
@@ -6,21 +6,17 @@ const newStudentForm = () => {
   <h2>New Student</h2>
   <form class="hide" id="new-student-form">
     <div class="form-group">
-      <label for="inputAddress">Address</label>
-      <input type="text" class="form-control" id="inputAddress" placeholder="1234 Main St">
+      <label for="inputImageUrl">Address</label>
+      <input type="text" class="form-control" id="inputImageUrl" placeholder="https://www.imgur.com">
     </div>
     <div class="form-row">
       <div class="form-group col-md-6">
-        <label for="inputName">Name</label>
+        <label for="inputName">Student Name</label>
         <input type="text" class="form-control" id="inputName">
       </div>
       <div class="form-group col-md-4">
-        <label for="inputPhone">Phone Number</label>
-        <input type="text" class="form-control" id="inputPhone">
-      </div>
-      <div class="form-group col-md-2">
-        <label for="inputProduct">Product</label>
-        <input type="text" class="form-control" id="inputProduct">
+        <label for="inputMajor">Major</label>
+        <input type="text" class="form-control" id="inputMajor">
       </div>
     </div>
     <button type="submit" class="btn btn-primary" id="submit-new-student">Submit New Student</button>

--- a/src/javascripts/helpers/data/student/studentData.js
+++ b/src/javascripts/helpers/data/student/studentData.js
@@ -21,18 +21,18 @@ const getStudents = () => new Promise((resolve, reject) => {
     .catch((err) => reject(err));
 });
 
-const addstudent = (newstudentObj) => axios.post(`${baseUrl}/student.json`, newstudentObj);
+const addStudent = (newStudentObj) => axios.post(`${baseUrl}/students.json`, newStudentObj);
 
-const deletestudent = (studentId) => axios.delete(`${baseUrl}/student/${studentId}.json`);
+const deleteStudent = (studentId) => axios.delete(`${baseUrl}/students/${studentId}.json`);
 
-const getstudentById = (id) => axios.get(`${baseUrl}/student/${id}.json`);
+const getStudentById = (id) => axios.get(`${baseUrl}/students/${id}.json`);
 
-const updatestudent = (id, updatestudentObj) => axios.put(`${baseUrl}/student/${id}.json`, updatestudentObj);
+const updateStudent = (id, updateStudentObj) => axios.put(`${baseUrl}/students/${id}.json`, updateStudentObj);
 
 export default {
-  addstudent,
-  deletestudent,
+  addStudent,
+  deleteStudent,
   getStudents,
-  getstudentById,
-  updatestudent,
+  getStudentById,
+  updateStudent,
 };

--- a/src/javascripts/helpers/listeners.js
+++ b/src/javascripts/helpers/listeners.js
@@ -62,18 +62,14 @@ const submitUpdateStudentForm = (e) => {
   e.preventDefault();
   const fbStudentId = e.target.getAttribute('data-firebase-student-id');
 
-  const inputAddress = $('#inputAddress').val();
+  const inputImageUrl = $('#inputImageUrl').val();
   const inputName = $('#inputName').val();
-  const inputPhone = $('#inputPhone').val();
-  const inputProduct = $('#inputProduct').val();
-  const studentId = e.target.getAttribute('data-studentId');
+  const inputMajor = $('#inputMajor').val();
 
   const newStudentObj = {
-    address: inputAddress,
-    name: inputName,
-    phoneNumber: inputPhone,
-    product: inputProduct,
-    studentId,
+    imageUrl: inputImageUrl,
+    studentName: inputName,
+    major: inputMajor,
   };
 
   studentData.updateStudent(fbStudentId, newStudentObj)
@@ -88,18 +84,14 @@ const submitNewStudentForm = (e) => {
   e.preventDefault();
 
   // get values from form
-  const inputAddress = $('#inputAddress').val();
+  const inputImageUrl = $('#inputImageUrl').val();
   const inputName = $('#inputName').val();
-  const inputPhone = $('#inputPhone').val();
-  const inputProduct = $('#inputProduct').val();
-  const studentId = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+  const inputMajor = $('#inputMajor').val();
 
   const newStudentObj = {
-    address: inputAddress,
-    name: inputName,
-    phoneNumber: inputPhone,
-    product: inputProduct,
-    studentId,
+    imageUrl: inputImageUrl,
+    studentName: inputName,
+    major: inputMajor,
   };
 
   studentData.addStudent(newStudentObj)


### PR DESCRIPTION
Closes #92.

The add and edit forms for students now reference the correct fields and properly update the respective clowns.

I've tested that adding a clown, editing a clown's attributes, and deleting them should now all work.